### PR TITLE
Remove certifi package requirement and update curl request

### DIFF
--- a/eks.py
+++ b/eks.py
@@ -13,7 +13,7 @@ def check_eks():
     eks = boto3.client('eks')
     response = requests.get('https://docs.aws.amazon.com/eks/latest/userguide/doc-history.rss')
     response.text
-    latest = "curl -s https://docs.aws.amazon.com/eks/latest/userguide/doc-history.rss | grep '<title>Kubernetes version' | sed -n '1p'"
+    latest = "curl -s https://docs.aws.amazon.com/eks/latest/userguide/doc-history.rss | grep '<title>Kubernetes version [0-9]' | sed -n '1p'"
     output = subprocess.check_output(latest, shell=True, universal_newlines=True)
     sed_command = "sed 's/[^0-9.]*//g'"
     eks_latest_version = subprocess.check_output(sed_command, input=output, shell=True, universal_newlines=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto3==1.24.84
 botocore==1.27.84
-certifi==2023.5.7
 charset-normalizer==3.2.0
 click==8.1.3
 idna==3.4


### PR DESCRIPTION
- Remove certifi package requirement as not needed and version was vulnerable.
- Update the curl request to get the version of EKS, issues were with matching.